### PR TITLE
Add KokoroTTSIsolated service to fix Metal assertion failures on macOS

### DIFF
--- a/server/bot.py
+++ b/server/bot.py
@@ -22,7 +22,8 @@ from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.openai.llm import OpenAILLMService
-from kokoro_tts import KokoroTTSService
+# from kokoro_tts import KokoroTTSService
+from kokoro_tts_isolated import KokoroTTSIsolated
 from pipecat.services.whisper.stt import WhisperSTTServiceMLX, MLXModel
 from pipecat.transports.base_transport import TransportParams
 from pipecat.processors.frameworks.rtvi import RTVIConfig, RTVIObserver, RTVIProcessor
@@ -44,10 +45,6 @@ ice_servers = [
 
 SYSTEM_INSTRUCTION = """
 "You are Pipecat, a friendly, helpful chatbot.
-
-You are running a voice AI tech stack entirely locally, on macOS. Whisper for speech-to-text, a Qwen3 model with 235 billion parameters for language understanding, and Kokoro for speech synthesis. The pipeline also uses Silero VAD and the open source, native audio smart-turn v2 model.
-
-Your goal is to demonstrate your capabilities in a succinct way.
 
 Your input is text transcribed in realtime from the user's voice. There may be transcription errors. Adjust your responses automatically to account for these errors.
 
@@ -75,16 +72,15 @@ async def run_bot(webrtc_connection):
 
     stt = WhisperSTTServiceMLX(model=MLXModel.LARGE_V3_TURBO_Q4)
 
-    tts = KokoroTTSService(model="prince-canuma/Kokoro-82M", voice="af_heart", sample_rate=24000)
-    # Alternative: Process-isolated version to avoid Metal assertion failures on some systems
-    # from kokoro_tts_isolated import KokoroTTSIsolated
-    # tts = KokoroTTSIsolated(model="prince-canuma/Kokoro-82M", voice="af_heart", sample_rate=24000)
+    # tts = KokoroTTSService(model="prince-canuma/Kokoro-82M", voice="af_heart", sample_rate=24000)
+    # Process-isolated version to avoid Metal assertion failures (now refactored to use standalone worker)
+    tts = KokoroTTSIsolated(model="prince-canuma/Kokoro-82M", voice="af_heart", sample_rate=24000)
 
     llm = OpenAILLMService(
-        api_key=None,
+        api_key="dummyKey",
         model="google/gemma-3-12b",  # Medium-sized model. Uses ~8.5GB of RAM.
         # model="mlx-community/Qwen3-235B-A22B-Instruct-2507-3bit-DWQ", # Large model. Uses ~110GB of RAM!
-        base_url="http://localhost:8000/v1",
+        base_url="http://127.0.0.1:1234/v1",
         max_tokens=4096,
     )
 

--- a/server/kokoro_worker.py
+++ b/server/kokoro_worker.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Standalone Kokoro TTS worker process.
+
+This worker runs in complete isolation to avoid Metal threading conflicts.
+It communicates via JSON over stdin/stdout.
+
+Usage:
+    python kokoro_worker.py
+
+Commands:
+    {"cmd": "init", "model": "prince-canuma/Kokoro-82M", "voice": "af_heart"}
+    {"cmd": "generate", "text": "Hello world"}
+"""
+
+import sys
+import json
+import base64
+import traceback
+import numpy as np
+
+# Add logging to worker
+import logging
+logging.basicConfig(level=logging.INFO, format='WORKER: %(message)s')
+
+try:
+    import mlx.core as mx
+    from mlx_audio.tts.utils import load_model
+    MLX_AVAILABLE = True
+except ImportError:
+    MLX_AVAILABLE = False
+
+
+class Worker:
+    def __init__(self):
+        self.model = None
+        self.voice = None
+        
+    def initialize(self, model_name, voice):
+        if not MLX_AVAILABLE:
+            return {"error": "MLX not available"}
+        try:
+            self.model = load_model(model_name)
+            self.voice = voice
+            # Test generation to ensure everything works
+            list(self.model.generate(text="test", voice=voice, speed=1.0))
+            return {"success": True}
+        except Exception as e:
+            return {"error": str(e)}
+    
+    def generate(self, text):
+        try:
+            if not self.model:
+                return {"error": "Not initialized"}
+            
+            segments = []
+            for result in self.model.generate(text=text, voice=self.voice, speed=1.0):
+                # Convert MLX array to numpy immediately
+                audio_data = np.array(result.audio, copy=True)
+                print(f"Generated segment shape: {audio_data.shape}, min: {audio_data.min():.4f}, max: {audio_data.max():.4f}", file=sys.stderr)
+                segments.append(audio_data)
+            
+            if not segments:
+                return {"error": "No audio"}
+                
+            # Concatenate all segments
+            if len(segments) == 1:
+                audio = segments[0]
+            else:
+                audio = np.concatenate(segments, axis=0)
+            
+            print(f"Final audio shape: {audio.shape}, min: {audio.min():.4f}, max: {audio.max():.4f}", file=sys.stderr)
+            
+            # Check if audio is silent
+            if np.max(np.abs(audio)) < 1e-6:
+                return {"error": "Generated audio is silent"}
+            
+            # Convert to 16-bit PCM
+            audio_int16 = (audio * 32767).astype(np.int16)
+            audio_b64 = base64.b64encode(audio_int16.tobytes()).decode()
+            
+            return {"success": True, "audio": audio_b64}
+        except Exception as e:
+            import traceback
+            return {"error": f"{str(e)}\n{traceback.format_exc()}"}
+
+
+def main():
+    """Main worker loop - reads commands from stdin, writes responses to stdout."""
+    worker = Worker()
+    
+    for line in sys.stdin:
+        try:
+            req = json.loads(line.strip())
+            if req["cmd"] == "init":
+                resp = worker.initialize(req["model"], req["voice"])
+            elif req["cmd"] == "generate":
+                resp = worker.generate(req["text"])
+            else:
+                resp = {"error": "Unknown command"}
+            print(json.dumps(resp), flush=True)
+        except Exception as e:
+            print(json.dumps({"error": str(e)}), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
  Adds `KokoroTTSIsolated` class that runs Kokoro TTS in a separate subprocess to prevent Metal threading assertion failures on macOS.

  ## Problem
  The standard `KokoroTTSService` can crash with Metal assertion errors after running for several minutes:
  -[_MTLCommandBuffer addCompletedHandler:]:976: failed assertion `Completed handler provided after commit call'

  ## Solution
  - Implements subprocess-based isolation for Kokoro TTS operations
  - Runs MLX Audio operations in separate Python process to avoid Metal threading conflicts
  - Maintains same API as `KokoroTTSService` for drop-in replacement
  - Includes proper cleanup and error handling

  ## Usage
  ```python
  # Replace this:
  from kokoro_tts import KokoroTTSService
  tts = KokoroTTSService(model="prince-canuma/Kokoro-82M", voice="af_heart")

  # With this:
  from kokoro_tts_isolated import KokoroTTSIsolated
  tts = KokoroTTSIsolated(model="prince-canuma/Kokoro-82M", voice="af_heart")

  Testing

  Tested on macOS with M1_16GB - eliminates Metal assertion crashes during extended voice conversations.