### PR TITLE
Add Kokoro MLX TTS implementation with process isolation

### DIFF
--- a/server/kokoro_tts_mlx_isolated.py
+++ b/server/kokoro_tts_mlx_isolated.py
@@ -1,6 +1,6 @@
 #
-# Completely isolated Kokoro TTS using separate process
-# Final attempt to avoid Metal threading issues
+# Process-isolated Kokoro TTS service
+# Uses a separate process to avoid Metal threading conflicts on Apple Silicon
 #
 
 import asyncio
@@ -26,13 +26,13 @@ from pipecat.services.tts_service import TTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
 
 
-class KokoroTTSIsolated(TTSService):
+class KokoroTTSMLXIsolated(TTSService):
     """Completely isolated Kokoro TTS using subprocess to avoid Metal issues."""
 
     def __init__(
         self,
         *,
-        model: str = "prince-canuma/Kokoro-82M",
+        model: str = "mlx-community/Kokoro-82M-bf16",
         voice: str = "af_heart",
         device: Optional[str] = None,
         sample_rate: int = 24000,
@@ -66,7 +66,7 @@ class KokoroTTSIsolated(TTSService):
         if not worker_path.exists():
             raise FileNotFoundError(
                 f"Worker script not found at {worker_path}. "
-                "Make sure kokoro_worker.py is in the same directory as kokoro_tts_isolated.py"
+                "Make sure kokoro_worker.py is in the same directory as kokoro_tts_mlx_isolated.py"
             )
         
         return str(worker_path)

--- a/server/kokoro_worker.py
+++ b/server/kokoro_worker.py
@@ -9,7 +9,7 @@ Usage:
     python kokoro_worker.py
 
 Commands:
-    {"cmd": "init", "model": "prince-canuma/Kokoro-82M", "voice": "af_heart"}
+    {"cmd": "init", "model": "mlx-community/Kokoro-82M-bf16", "voice": "af_heart"}
     {"cmd": "generate", "text": "Hello world"}
 """
 


### PR DESCRIPTION
## Summary
- Add KokoroTTSMLXIsolated: Process-isolated TTS service that avoids Metal threading conflicts on Apple Silicon
- Add KokoroTTSMLXInProcess: In-process alternative (marked unstable due to Metal issues)  
- Add kokoro_worker.py: Standalone worker script for isolated process communication
- Update bot.py to use isolated version by default with clear documentation

## Problem Solved
The existing Kokoro TTS implementations cause Metal command buffer assertion failures on Apple Silicon systems due to MLX threading conflicts. This implementation completely isolates the MLX operations in a separate process to eliminate these issues.

## Key Features
- **Process isolation**: Completely separate process for MLX operations
- **JSON communication**: Clean stdin/stdout protocol between main process and worker
- **Production ready**: Stable isolated version set as default
- **Development option**: In-process version included but marked as unstable for debugging

## Test plan
- [x] Verify isolated TTS generates audio without Metal assertion failures
- [x] Test worker process startup and communication
- [x] Confirm clean process shutdown and cleanup
- [x] Validate bot.py integration works with new service

🤖 Generated with [Claude Code](https://claude.ai/code)